### PR TITLE
Increase readability, add a space between X labels

### DIFF
--- a/src/babar.coffee
+++ b/src/babar.coffee
@@ -173,7 +173,8 @@ module.exports = (points, options={}) ->
   lblXN = numBkts
   lblXI = 1
 
-  while lblXN * lblXW >= numBkts * bktW
+  # + 1 to have at least one space between label
+  while (lblXN + 1) * lblXW >= numBkts * bktW
     lblXN = Math.floor lblXN / 2
     lblXI *= 2
 


### PR DESCRIPTION
Before:
```

  0 __________________████████████████████████████████████████████████████
    0   400 800 12001600200024002800320036004000440048005200560060006400

```
After:

  ```
0 __________________████████████████████████████████████████████████████
    0       800     1600    2400    3200    4000    4800    5600
```